### PR TITLE
Fix usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ generated at startup, as well as renewed (if necessary) once a week.
 docker run \
     -e CERTS=my.domain,my.other.domain \
     -e EMAIL=my.email@my.domain \
-    -v /etc/letsencrypt:/srv/letsencrypt \
-    -p 80:90 -p 443:443
+    -v /etc/letsencrypt:/etc/letsencrypt \
+    -p 80:90 -p 443:443 \
     bradjonesllc/docker-haproxy-letsencrypt
 ```
 


### PR DESCRIPTION
Hi
I'm evaluating your docker image as it seems to answer my needs perfectly.

To get it running I 
- added a backslash on the second-to-last line of the usage example
- fix port binding to expose port `80` instead of `90`
- assumed it makes more sense to mount the directory `/etc/letsencrypt` where the account data and the certificates get stored

Thanks for your work!
